### PR TITLE
feat: Implement basic rectangle crop for #38

### DIFF
--- a/frontend/src/components/AlbumEdit.css
+++ b/frontend/src/components/AlbumEdit.css
@@ -93,3 +93,21 @@
   flex-grow: 1;
   overflow-y: auto; /* サイドバーコンテンツが多い場合にスクロール */
 }
+.album-object.selected {
+  outline: 2px solid blue;
+  box-shadow: 0 0 10px rgba(0, 0, 255, 0.5);
+}
+
+.crop-overlay-shape {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 2px dashed yellow;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
Implemented basic rectangle cropping functionality. Users can select a photo, activate shape crop mode, and confirm the crop. The crop information (x, y, width, height relative to the original photo object) is saved to the object's contentData.cropInfo. Further UI improvements for interactive cropping (drag/resize) and other crop shapes (freehand) will be addressed in subsequent tasks.