### PR TITLE
fix(frontend): Correct albumId passing to edit page (issue #72)

### DIFF
--- a/definitions/repo/implementation.txt
+++ b/definitions/repo/implementation.txt
@@ -1,0 +1,40 @@
+File: frontend/src/components/AlbumList.tsx
+Function: AlbumList (React.FC)
+Short Description: Changed album ID property from `id` to `albumId` in the `Album` interface and updated its usage within the component to correctly pass the `albumId` to the album edit page route. This resolves an issue where `undefined` was being passed as the album ID.
+Input / Output:
+  Input: None
+  Output: JSX.Element (Album list UI)
+
+File: frontend/src/components/AlbumEdit.tsx
+Function: handlePhotoUploadDrop
+Short Description: 写真アップロード時にAPIレスポンスのキー名 (`filePath`, `originalFilename`) をフロントエンドの `Photo` インターフェースのキー名 (`url`, `name`) に正しくマッピングするように修正しました。これにより、アップロードされた写真のURLと名前が正しくステートに保存され、画像表示エラーの解消が期待されます。
+Input / Output:
+  Input: e: React.DragEvent<HTMLDivElement>
+  Output: Promise<void> (内部で `photos` ステートを更新)
+File: backend/src/routes/albums.ts
+Function: GET /albums/:albumId (router.get('/:albumId', ...))
+Short Description: パスパラメータとして渡される albumId に対するUUID形式のバリデーションを追加しました。また、内部で写真オブジェクトの photoId を扱う際にもUUID形式のバリデーションを追加し、不正なIDによるデータベースエラーを防止します。エラーロギングも強化しました。
+Input / Output:
+  Input: req: Request (params: { albumId: string }), res: Response
+  Output: Response (JSON or error)
+
+File: backend/src/routes/albums.ts
+Function: PUT /albums/:albumId/objects/:objectId (router.put('/:albumId/objects/:objectId', ...))
+Short Description: パスパラメータとして渡される albumId および objectId に対するUUID形式のバリデーションを追加しました。また、リクエストボディの contentData 内に含まれる photoId に対してもUUID形式のバリデーションを追加しました。
+Input / Output:
+  Input: req: Request (params: { albumId: string, objectId: string }, body: { ... }), res: Response
+  Output: Response (JSON or error)
+
+File: backend/src/routes/albums.ts
+Function: DELETE /albums/:albumId/objects/:objectId (router.delete('/:albumId/objects/:objectId', ...))
+Short Description: パスパラメータとして渡される albumId および objectId に対するUUID形式のバリデーションを追加しました。
+Input / Output:
+  Input: req: Request (params: { albumId: string, objectId: string }), res: Response
+  Output: Response (status 204 or error)
+
+File: backend/src/routes/albums.ts
+Function: POST /albums/:albumId/objects (router.post('/:albumId/objects', ...))
+Short Description: リクエストボディの contentData 内に含まれる photoId (typeが'photo'の場合) に対するUUID形式のバリデーションを追加しました。
+Input / Output:
+  Input: req: Request (params: { albumId: string }, body: { pageId: string, type: string, ..., contentData: { photoId?: string } }), res: Response
+  Output: Response (JSON or error)

--- a/frontend/src/components/AlbumList.tsx
+++ b/frontend/src/components/AlbumList.tsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 
 interface Album {
-  id: number;
+  albumId: string; // id から albumId に変更し、型をstringに修正
   title: string;
   createdAt: string;
   thumbnailUrl?: string; // Optional: If you have thumbnails
@@ -104,7 +104,7 @@ const AlbumList: React.FC = () => {
 
         {/* Album Items */}
         {albums.map((album) => (
-          <div key={album.id} className="border rounded-lg p-4 hover:shadow-lg cursor-pointer" onClick={() => navigate(`/albums/${album.id}`)}>
+          <div key={album.albumId} className="border rounded-lg p-4 hover:shadow-lg cursor-pointer" onClick={() => navigate(`/albums/${album.albumId}`)}>
             <div className="w-full h-32 bg-gray-200 mb-2 rounded flex items-center justify-center">
               {/* TODO: Replace with actual thumbnail if available */}
               <span className="text-gray-500">{album.thumbnailUrl ? <img src={album.thumbnailUrl} alt={album.title} className="object-cover w-full h-full rounded"/> : 'サムネイルなし'}</span>


### PR DESCRIPTION
Fixes #72 by ensuring the correct albumId property is used when navigating from the album list to the album edit page. This resolves the bug where albumId was undefined.